### PR TITLE
Fix: newfoundland product page comparison image max height

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -3337,7 +3337,7 @@ body .brand-comare-wrapper {
 .comparison-table-image img {
   display: block;
   width: 100%;
-  max-height: 600px;
+  max-height: 750px;
 }
 
 .brand-comare-table {


### PR DESCRIPTION
In the newfoundland product page, product comparison in the form of an image is squeezed. Max-height is changed to 750px since the image itself is around 740px.